### PR TITLE
Fixing the path to the non-existing temporary files, due to git has reference to /dev/null

### DIFF
--- a/src/diff.py
+++ b/src/diff.py
@@ -22,8 +22,8 @@ if __name__ == '__main__':
         _, numlines, workbook_name, workbook_b, _, _, workbook_a, _, _ = sys.argv
         numlines = int(numlines)
 
-    path_workbook_a = os.path.abspath(workbook_a) if workbook_a != 'nul' else None
-    path_workbook_b = os.path.abspath(workbook_b) if workbook_b != 'nul' else None
+    path_workbook_a = os.path.abspath(workbook_a) if workbook_a != 'nul' and workbook_a != '/dev/null' else None
+    path_workbook_b = os.path.abspath(workbook_b) if workbook_b != 'nul' and workbook_b != '/dev/null' else None
 
     workbook_a = Workbook(path_workbook_a) if path_workbook_a is not None else None
     workbook_b = Workbook(path_workbook_b) if path_workbook_b is not None else None


### PR DESCRIPTION
Hi all, thank you for a such useful tool.
I have faced the same problem as #49 . (I have installed git-xl with installer, OS - Windows 10 1903, git version 2.24.0.windows.2)
As I found in git sources - [internal diff](https://github.com/git/git/blob/d8437c57fa0752716dde2d3747e7c22bf7ce2e41/diff.c#L3440) and also checked locally, in diff.py there will be not 'nul', but '/dev/null'.
Thank you in advance
